### PR TITLE
Fix compatibility with Serializer.is_valid

### DIFF
--- a/generic_relations/serializers.py
+++ b/generic_relations/serializers.py
@@ -6,6 +6,7 @@ from django.utils.translation import ugettext_lazy as _
 from django import forms
 
 from rest_framework import serializers
+from rest_framework.settings import api_settings
 
 
 __all__ = ('GenericSerializerMixin', 'GenericModelSerializer',)
@@ -38,7 +39,7 @@ class GenericSerializerMixin(object):
         try:
             serializer = self.get_deserializer_for_data(data)
         except ImproperlyConfigured as e:
-            raise serializers.ValidationError(e)
+            raise serializers.ValidationError({api_settings.NON_FIELD_ERRORS_KEY: e})
         return serializer.to_internal_value(data)
 
     def to_representation(self, instance):

--- a/generic_relations/tests/test_relations.py
+++ b/generic_relations/tests/test_relations.py
@@ -9,6 +9,7 @@ from django.test.utils import override_settings
 
 from rest_framework import serializers
 from rest_framework.reverse import reverse
+from rest_framework.settings import api_settings
 
 from generic_relations.relations import GenericRelatedField
 from generic_relations.tests.models import Bookmark, Detachable, Note, NoteProxy, Tag
@@ -385,7 +386,7 @@ class TestGenericRelatedFieldDeserialization(TestCase):
         })
 
         message = 'Could not determine a valid serializer for value %r.'
-        expected = {'tagged_item': [message % 'foo-bar']}
+        expected = {'tagged_item': {api_settings.NON_FIELD_ERRORS_KEY: message % 'foo-bar'}}
 
         self.assertFalse(serializer.is_valid())
         self.assertEqual(expected, serializer.errors)

--- a/generic_relations/tests/test_serializers.py
+++ b/generic_relations/tests/test_serializers.py
@@ -71,3 +71,12 @@ class TestGenericModelSerializer(TestCase):
             {'text': 'Reticulate the splines'},
             {'url': 'https://www.djangoproject.com/'},
         ])
+
+    def test_is_valid_raise_exception(self):
+        serializer = GenericModelSerializer(
+            serializers={Bookmark: BookmarkSerializer()},
+            data={'url': 'not-a-url'},
+            )
+
+        with self.assertRaises(serializers.ValidationError):
+            serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
In #44 I changed the error raised by `to_internal_value` without realizing this is still incompatible with `Serializer.is_valid` which expects a `ValidationError` with a dict `detail` (see [docs](https://www.django-rest-framework.org/api-guide/serializers/#to_internal_valueself-data)). This fixes the issue with a small backwards incompatibility (see test_relations.py), but this is what the rest framework expects. I added a test which runs `is_valid`.