### PR TITLE
GH actions fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.6"
+          - "3.7"
           - "3.11"
         django-version:
           - "2.2"
@@ -27,6 +27,10 @@ jobs:
             drf-version: "3.14"
           - django-version: "3.1"
             drf-version: "3.14"
+          - django-version: "4.1"
+            drf-version: "3.11"
+          - django-version: "4.1"
+            drf-version: "3.12"
 
     name: "py${{ matrix.python-version}} dj${{ matrix.django-version }} drf${{ matrix.drf-version }}"
 


### PR DESCRIPTION
Saw that my updatesin #64 made GH actions to fail.
It seems GH actions no longer support python 3.6 and django 4.1 is not fully supported from drf < 3.13 as it requires pytz.
These changes will probably fix this.